### PR TITLE
[fusionar] Ajustes para descartar más rápido

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-
-toponimos.txt
-profesiones.txt
+*.txt

--- a/fusionar.py
+++ b/fusionar.py
@@ -2,34 +2,47 @@
 
 from pywikibot import pagegenerators as pg
 import pywikibot
-import time
 
-#código que busca en la categoría de artículos con la plantilla fusionar y comprueba si el artículo con el que debería fusionarse existe o no. Si no existe se graba en un fichero
+categories_fusionar = ['fusionar en', 'fusionar a',
+                       'fusionar hacia', 'fusionar desde', 'fusionar']
+
+
+def write(data='', file='fusionar.txt'):
+    f = open(file, "a", encoding='utf8')
+    f.write(data + '\n')
+    f.close()
+
+# código que busca en la categoría de artículos con la plantilla fusionar y comprueba si el artículo con el que debería fusionarse existe o no. Si no existe se graba en un fichero
+
+
 def main():
     site = pywikibot.Site("es", "wikipedia")
-    cat = pywikibot.Category(site,'Categoría:Wikipedia:Fusionar')
-    gen = pg.CategorizedPageGenerator(cat)
-    for page in gen:
-        print("<<<<<<<<<<<<<<  " + page.title())
+    cat = pywikibot.Category(site, 'Categoría:Wikipedia:Fusionar')
+    gen = pg.CategorizedPageGenerator(cat, namespaces=[0, 100])
+    articles = pg.PreloadingGenerator(gen)
+    for page in articles:
+        print("<<<<<<<<<<<<<< {0} ".format(page.title()))
         page_str = page.get()
         tmpl_list = pywikibot.textlib.extract_templates_and_params(page_str)
-        for tipo in tmpl_list:
-            if ("fusionar" in tipo) or ("fusionar en" in tipo) or ("fusionar a" in tipo) or ("fusionar hacia" in tipo) or ("fusionar desde" in tipo)  or ("Fusionar" in tipo):
-                  for fus in tipo:
-                    if ("fusionar" in fus) or ("Fusionar" in fus):
-                       continue
+        templates_to_check = filter(
+            lambda x: x[0].lower() in categories_fusionar, tmpl_list)
+        for tipo in templates_to_check:
+            plantilla, parametros = tipo
+            if '1' not in parametros:
+                write(data='[!!] Falta parámetro en {0}'.format(
+                    str(page.title())))
+                continue
+            else:
+                try:
+                    nueva_pagina = pywikibot.Page(site, str(parametros['1']))
+                    if(nueva_pagina.exists() == False):
+                        write(data=str(page.title()))
                     else:
-                        try:
-                            nueva_pagina=pywikibot.Page(site, str(fus['1']))
-                            if(nueva_pagina.exists()==False):
-                                f = open ("erroresFusionar.txt", mode='a', encoding='utf-8')
-                                f.write(str(page.title()) + '\n')
-                                f.close()
-                        except:
-                            f = open ("erroresFusionar.txt", mode='a', encoding='utf-8')
-                            f.write('Error en: ' + str(page.title()) + '\n')
-                            f.close()
-        print ("\n")
+                        print('La página {0} existe'.format(
+                            nueva_pagina.title()))
+                except Exception:
+                    write(data='[!] Error en {0}'.format(str(page.title())))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Usando _chapuceramente_ las opciones de Python, descartamos las páginas que no poseen la plantilla (solo por si las dudas), así como dejé un método más centralizado (`write`) para evitar duplicación de código.

Por último, identifico las plantillas que no poseen parámetro de fusionar, ya que solamente se ha dejado la plantilla...